### PR TITLE
Parse lines before spaces

### DIFF
--- a/AttrTextView copy.swift
+++ b/AttrTextView copy.swift
@@ -43,8 +43,11 @@ class AttrTextView: UITextView {
     
     private func setAttrWithName(attrName: String, wordPrefix: String, color: UIColor, text: String, font: UIFont) {
         //Words can be separated by either a space or a line break
-        var words = text.components(separatedBy: " ")
-        words.append(contentsOf: text.components(separatedBy: "\n"))
+        let lines = text.components(separatedBy: "\n")
+        var words: [String] = []
+        for line in lines {
+            words.append(contentsOf: line.components(separatedBy: " "))
+        }
        
         //Filter to check for the # or @ prefix
         for word in words.filter({$0.hasPrefix(wordPrefix)}) {


### PR DESCRIPTION
There was an issue where if you started your text with '@' or '#' (didn't put a space in front of it), the newline parse would pick up the whole line and interpret it as its own word. This would cause the entire line (regardless of spacing) to get unintended attributes. This fix parses by lines, then parses each line by spaces in order to obtain the words.

